### PR TITLE
Correct spelling of library.properties' includes field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=not a beginners library
 category=Other
 url=https://github.com/RobTillaart/avrheap
 architectures=avr
-include=avrheap.h 
+includes=avrheap.h 
 depends=


### PR DESCRIPTION
`include` -> `includes`

The misspelled field name doesn't actually cause a problem currently, since the Arduino IDE's behavior is the same even without an `includes` field with a library that has only a single header file, but it would be a problem if another header file was added later. I noticed the typo, so thought I might as well submit a PR.